### PR TITLE
Add search filter

### DIFF
--- a/evento/src/components/SearchBar/index.js
+++ b/evento/src/components/SearchBar/index.js
@@ -5,11 +5,11 @@ class SearchBar extends Component {
 	render() {
 		return (
 			<div className="SearchBar">
-				<input 
+				<input
 					type="text"
 					name="search"
 					placeholder="search evento"
-					onChange={this.props.updateFilter}>
+					onChange={this.props.onQueryChange}>
 				</input>
 			</div>
 		);

--- a/evento/src/components/SearchBar/index.js
+++ b/evento/src/components/SearchBar/index.js
@@ -5,7 +5,12 @@ class SearchBar extends Component {
 	render() {
 		return (
 			<div className="SearchBar">
-				<input type="text" name="search" placeholder="search evento"></input>
+				<input 
+					type="text"
+					name="search"
+					placeholder="search evento"
+					onChange={this.props.updateFilter}>
+				</input>
 			</div>
 		);
 	}

--- a/evento/src/views/Explore/Explore.test.js
+++ b/evento/src/views/Explore/Explore.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Explore from './';
 
+const eventFilterer = (events) => events;
 it('renders without crashing', () => {
 	const div = document.createElement('div');
-	ReactDOM.render(<Explore />, div);
+	ReactDOM.render(<Explore filterEvents={eventFilterer} />, div);
 });

--- a/evento/src/views/Explore/index.js
+++ b/evento/src/views/Explore/index.js
@@ -16,25 +16,16 @@ class Explore extends Component {
 			this.setState({ events: events });
 		});
 	}
-	
-	isVisible(event, filterQuery) {
-		const includedProps = [event.title, event.description, event.category.name, 
-			event.creator.name, event.location];
 
-		const cleaned = includedProps
-			.filter(prop => typeof prop === 'string')
-			.map(prop => prop.toLowerCase());
-
-		return cleaned.some((element) => element.includes(filterQuery.toLowerCase()));
+	get filteredEvents() {
+		return this.props.filterEvents(this.state.events);
 	}
 
 	render() {
-		const events = this.state.events;
-		const visibleEvents = events.filter(e => this.isVisible(e, this.props.filter));
 		return (
 			<div className="Explore">
 				<div className="event-card-list">
-					{ visibleEvents.map(event => <EventCard key={event.id} event={event} />) }
+					{ this.filteredEvents.map(event => <EventCard key={event.id} event={event} />) }
 				</div>
 			</div>
 		);

--- a/evento/src/views/Explore/index.js
+++ b/evento/src/views/Explore/index.js
@@ -7,8 +7,8 @@ class Explore extends Component {
 	constructor(props) {
 		super(props);
 		this.state = { events: [] };
-		
 	}
+
 	componentWillMount() {
 		fetch('/events')
 		.then(response => response.json())

--- a/evento/src/views/Explore/index.js
+++ b/evento/src/views/Explore/index.js
@@ -9,7 +9,7 @@ class Explore extends Component {
 		this.state = { events: [] };
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		fetch('/events')
 		.then(response => response.json())
 		.then(events => {

--- a/evento/src/views/Explore/index.js
+++ b/evento/src/views/Explore/index.js
@@ -4,21 +4,37 @@ import EventCard from '../../components/EventCard';
 import './Explore.css';
 
 class Explore extends Component {
+	constructor(props) {
+		super(props);
+		this.state = { events: [] };
+		
+	}
 	componentWillMount() {
-		this.setState({ events: [] });
-
 		fetch('/events')
 		.then(response => response.json())
 		.then(events => {
 			this.setState({ events: events });
 		});
 	}
+	
+	isVisible(event, filterQuery) {
+		const includedProps = [event.title, event.description, event.category.name, 
+			event.creator.name, event.location];
+
+		const cleaned = includedProps
+			.filter(prop => typeof prop === 'string')
+			.map(prop => prop.toLowerCase());
+
+		return cleaned.some((element) => element.includes(filterQuery.toLowerCase()));
+	}
 
 	render() {
+		const events = this.state.events;
+		const visibleEvents = events.filter(e => this.isVisible(e, this.props.filter));
 		return (
 			<div className="Explore">
 				<div className="event-card-list">
-					{this.state.events.map(event => <EventCard key={event.id} event={event} /> )}
+					{ visibleEvents.map(event => <EventCard key={event.id} event={event} />) }
 				</div>
 			</div>
 		);

--- a/evento/src/views/MainPage/MainPage.test.js
+++ b/evento/src/views/MainPage/MainPage.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import MainPage from './';
 
-it('renders without crashing');
-/*, () => {
+it('renders without crashing'); /*, () => {
 	const div = document.createElement('div');
-	ReactDOM.render(<MainPage />, div);
+	ReactDOM.render(<MainPage location={{ pathname: '/explore' }}/>, div);
 }); */

--- a/evento/src/views/MainPage/index.js
+++ b/evento/src/views/MainPage/index.js
@@ -14,15 +14,23 @@ const tabs = [
 ];
 
 class MainPage extends Component {
+	constructor() {
+		super();
+		this.state = { filter: '' };
+	}
+
+	updateFilter(evt) {
+		this.setState({ filter: evt.target.value });
+	}
 
 	render() {
 		return (
 			<div className="MainPage">
-				<SearchBar />
+				<SearchBar filter={this.updateFilter.bind(this)}/>
 				<TabContainer tabs={tabs} />
 
 				<Switch>
-					<Route exact path='/' component={Explore} />
+					<Route exact path='/' component={() => <Explore updateFilter={this.state.filter} />} />
 					<Route exact path='/events' component={MyEvents} />
 				</Switch>
 			</div>

--- a/evento/src/views/MainPage/index.js
+++ b/evento/src/views/MainPage/index.js
@@ -26,11 +26,11 @@ class MainPage extends Component {
 	render() {
 		return (
 			<div className="MainPage">
-				<SearchBar filter={this.updateFilter.bind(this)}/>
+				<SearchBar updateFilter={this.updateFilter.bind(this)}/>
 				<TabContainer tabs={tabs} />
 
 				<Switch>
-					<Route exact path='/' component={() => <Explore updateFilter={this.state.filter} />} />
+					<Route exact path='/' component={() => <Explore filter={this.state.filter} />} />
 					<Route exact path='/events' component={MyEvents} />
 				</Switch>
 			</div>

--- a/evento/src/views/MainPage/index.js
+++ b/evento/src/views/MainPage/index.js
@@ -13,14 +13,28 @@ const tabs = [
 	{ title: "My Events", path: "/events" }
 ];
 
+const createEventFilterer = (filterQuery) => {
+	return (events) => {
+		const toString = event => [
+			event.title, event.description, event.category.name,
+			event.creator.name, event.location]
+			.join('|')
+			.toLowerCase();
+
+		return events.filter(event => toString(event).includes(filterQuery));
+	}
+};
+
 class MainPage extends Component {
 	constructor() {
 		super();
-		this.state = { filter: '' };
+
+		// matches all events by default
+		this.state = { filterer: (events) => events };
 	}
 
-	updateFilter(evt) {
-		this.setState({ filter: evt.target.value });
+	updateFilter(filterQuery) {
+		this.setState({ filterer: createEventFilterer(filterQuery) });
 	}
 
 	changePath(path) {
@@ -30,14 +44,14 @@ class MainPage extends Component {
 	render() {
 		return (
 			<div className="MainPage">
-				<SearchBar updateFilter={this.updateFilter.bind(this)}/>
+				<SearchBar onQueryChange={(evt) => this.updateFilter(evt.target.value)}/>
 				<TabContainer
 					tabs={tabs}
 					path={this.props.location.pathname}
 					onSelectedTabChange={(tab) => this.changePath(tab.path)}/>
 
 				<Switch>
-					<Route exact path='/' render={() => <Explore filter={this.state.filter} />} />
+					<Route exact path='/' render={() => <Explore filterEvents={this.state.filterer} />} />
 					<Route exact path='/events' component={MyEvents} />
 				</Switch>
 			</div>

--- a/evento/src/views/MainPage/index.js
+++ b/evento/src/views/MainPage/index.js
@@ -30,7 +30,7 @@ class MainPage extends Component {
 				<TabContainer tabs={tabs} />
 
 				<Switch>
-					<Route exact path='/' component={() => <Explore filter={this.state.filter} />} />
+					<Route exact path='/' render={() => <Explore filter={this.state.filter} />} />
 					<Route exact path='/events' component={MyEvents} />
 				</Switch>
 			</div>


### PR DESCRIPTION
Initial version of the filter. The biggest problem with this approach is that `SearchBar` updates directly `MainPages` state and every time it changes, new `Explore` component is created and mounted. This causes new get request to `/events` for every letter typed in `SearchBar`. This could be avoided if `Explore` could directly read `SearchBars` text without altering `MainPages` state. Other way would be implementing some kind on global state like redux.

Closes #22