### PR TITLE
Add sign-in page

### DIFF
--- a/evento/package.json
+++ b/evento/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "/evento-web",
   "dependencies": {
+    "js-cookie": "^2.1.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   },
@@ -19,14 +20,11 @@
     "build-css": "node-sass src/ -o src/",
     "watch-css": "npm run build-css -- -q && node-sass src/ -o src/ --watch --recursive",
     "start-js": "react-scripts start",
-
     "start": "npm-run-all -p watch-css start-js",
     "build": "npm run build-css && react-scripts build",
-
     "test": "npm run build-css -- -q && react-scripts test --env=jsdom --coverage",
     "travis-test": "npm test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "deploy": "gh-pages -d build",
-
     "eject": "react-scripts eject"
   }
 }

--- a/evento/src/config.js
+++ b/evento/src/config.js
@@ -3,6 +3,6 @@ const BaseURL = 'https://evento-api.herokuapp.com';
 export default {
 	apply() {
 		const _fetch = window.fetch;
-		window.fetch = (url) => _fetch(BaseURL + url);
+		window.fetch = (url, ...params) => _fetch(BaseURL + url, ...params);
 	}
 } 

--- a/evento/src/views/App/index.js
+++ b/evento/src/views/App/index.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import MainPage from '../MainPage';
 import EventPage from '../EventPage';
+import SignInPage from '../SignInPage';
 import PathNotFound from './components/PathNotFound';
 import './App.css';
 
@@ -13,8 +14,9 @@ class App extends Component {
 			<div className="App">
 				<Router>
 					<Switch>
-						<Route exact path='/' component={MainPage} />
+						<Route exact path='/signin' component={SignInPage} />
 						<Route exact path='/event/:eventId' component={EventPage} />
+						<Route path='/' component={MainPage} />
 						<Route path='*' component={PathNotFound} />
 					</Switch>
 				</Router>

--- a/evento/src/views/App/index.js
+++ b/evento/src/views/App/index.js
@@ -14,9 +14,10 @@ class App extends Component {
 			<div className="App">
 				<Router>
 					<Switch>
+						<Route exact path='/' component={MainPage} />
+						<Route exact path='/events' component={MainPage} />
 						<Route exact path='/signin' component={SignInPage} />
 						<Route exact path='/event/:eventId' component={EventPage} />
-						<Route path='/' component={MainPage} />
 						<Route path='*' component={PathNotFound} />
 					</Switch>
 				</Router>

--- a/evento/src/views/MyEvents/index.js
+++ b/evento/src/views/MyEvents/index.js
@@ -1,14 +1,38 @@
 import React, { Component } from 'react';
-import './MyEvents.css'
+import Cookie from 'js-cookie';
+import EventCard from '../../components/EventCard';
+import './MyEvents.css';
 
 class MyEvents extends Component {
-	componentWillMount() {
+	constructor() {
+		super();
+		this.state = { events: [] };
+	}
+
+	componentDidMount() {
+		const userId = Cookie.get('userId');
+		const authToken = Cookie.get('auth_token');
+
+		fetch(`/users/${userId}/events`, {
+			headers: { 'Authorization': authToken }
+		}).then(response => response.json())
+		.then(events => {
+			this.setState({ events: events });
+		});
 	}
 
 	render() {
 		return (
 			<div className="MyEvents">
 				<h1>My Events: </h1>
+				<div className="event-card-list">
+					{ this.state.events.map(event =>
+						<EventCard
+							key={event.id}
+							event={event}
+							onClick={() => this.props.history.push(`/event/${event.id}`)}/>)
+					}
+				</div>
 			</div>
 		);
 	}

--- a/evento/src/views/MyEvents/index.js
+++ b/evento/src/views/MyEvents/index.js
@@ -10,15 +10,19 @@ class MyEvents extends Component {
 	}
 
 	componentDidMount() {
+		this.fetchEvents();
+	}
+	
+	fetchEvents() {
 		const userId = Cookie.get('userId');
 		const authToken = Cookie.get('auth_token');
 
-		fetch(`/users/${userId}/events`, {
-			headers: { 'Authorization': authToken }
-		}).then(response => response.json())
-		.then(events => {
-			this.setState({ events: events });
-		});
+		// If userId or authToken is not found do try to fetch events
+		if (!userId || !authToken) return;
+
+		fetch(`/users/${userId}/events`, { headers: { 'Authorization': authToken }})
+		.then(response => response.json())
+		.then(events => this.setState({ events: events }));
 	}
 
 	render() {
@@ -30,7 +34,8 @@ class MyEvents extends Component {
 						<EventCard
 							key={event.id}
 							event={event}
-							onClick={() => this.props.history.push(`/event/${event.id}`)}/>)
+							onClick={() => this.props.history.push(`/event/${event.id}`)}
+						/>)
 					}
 				</div>
 			</div>

--- a/evento/src/views/SignInPage/SignInPage.scss
+++ b/evento/src/views/SignInPage/SignInPage.scss
@@ -1,0 +1,3 @@
+.SignInPage { 
+	text-align: center;
+}

--- a/evento/src/views/SignInPage/SignInPage.scss
+++ b/evento/src/views/SignInPage/SignInPage.scss
@@ -1,3 +1,7 @@
 .SignInPage { 
 	text-align: center;
+
+	.ErrorMessage {
+		color: red;
+	}
 }

--- a/evento/src/views/SignInPage/SignInPage.test.js
+++ b/evento/src/views/SignInPage/SignInPage.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SignInPage from './';
+
+it('renders without crashing', () => {
+	const div = document.createElement('div');
+	ReactDOM.render(<SignInPage />, div);
+});

--- a/evento/src/views/SignInPage/index.js
+++ b/evento/src/views/SignInPage/index.js
@@ -5,7 +5,7 @@ import './SignInPage.css'
 class SignInPage extends Component {
 	constructor() {
 		super();
-		this.state = { 
+		this.state = {
 			email: '',
 			password: '',
 		 	errorMessage: ''
@@ -22,29 +22,28 @@ class SignInPage extends Component {
 				email: this.state.email,
 				password: this.state.password,
 			})
-		}).then(response => {
+		})
+		.then(response => {
 			if (response.status === 200) {
 				return response.json();
+			} else {
+				return Promise.reject(new Error('Invalid credentials'));
 			}
-			this.setState({ errorMessage: 'Invalid credentials' });
-		}).then(authKey => {
+		})
+		.then(authKey => {
 			Cookie.set('auth_token', authKey.auth_token);
-
-			// User id needs to be fetched and saved to cookie
-			fetch('/users')
-			.then(response => response.json())
-			.then(users => users.filter(user => user.email === this.state.email)[0])
-			.then(user => Cookie.set('userId', user.id))
+			Cookie.set('userId', authKey.user.id)
 
 			// Move to front page after successiful sign in
 			this.props.history.push('/')
-		});
+		})
+		.catch(error => this.setState({ errorMessage: error.message}));
 	}
 
 	render() {
 		return (
 			<form className='SignInPage' onSubmit={(e) => this.handleSubmit(e)}>
-				<p>{this.state.errorMessage}</p>
+				<p className="ErrorMessage">{this.state.errorMessage}</p>
 				<label>
 					Email:<br/>
 					<input type="text" value={this.state.email} onChange={(evt) => this.setState({email: evt.target.value})} />

--- a/evento/src/views/SignInPage/index.js
+++ b/evento/src/views/SignInPage/index.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import Cookie from 'js-cookie';
+import './SignInPage.css'
+
+class SignInPage extends Component {
+	constructor() {
+		super();
+		this.state = { 
+			email: '',
+			password: '',
+		 	errorMessage: ''
+		};
+	}
+
+	handleSubmit(evt) {
+		evt.preventDefault();
+
+		fetch('/authenticate', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin':'*' },
+			body: JSON.stringify({
+				email: this.state.email,
+				password: this.state.password,
+			})
+		}).then(response => {
+			if (response.status === 200) {
+				return response.json();
+			}
+			this.setState({ errorMessage: 'Invalid credentials' });
+		}).then(authKey => {
+			Cookie.set('auth_token', authKey.auth_token);
+
+			// User id needs to be fetched and saved to cookie
+			fetch('/users')
+			.then(response => response.json())
+			.then(users => users.filter(user => user.email === this.state.email)[0])
+			.then(user => Cookie.set('userId', user.id))
+
+			// Move to front page after successiful sign in
+			this.props.history.push('/')
+		});
+	}
+
+	render() {
+		return (
+			<form className='SignInPage' onSubmit={(e) => this.handleSubmit(e)}>
+				<p>{this.state.errorMessage}</p>
+				<label>
+					Email:<br/>
+					<input type="text" value={this.state.email} onChange={(evt) => this.setState({email: evt.target.value})} />
+					<br/>Password:<br/>
+					<input type="password" value={this.state.password} onChange={(evt) => this.setState({password: evt.target.value})} />
+				</label><br/>
+				<input type="submit" value="Submit" />
+			</form>
+		);
+	}
+}
+
+export default SignInPage;


### PR DESCRIPTION
Even though back end does not yet use authentication (see anttilip/evento-server#17) I've tested this with a local dev server running and it worked fine. This PR should not be merged until tested with the production server. I also added event cards to My Events page to test.

For cookies I used [js-cookie](https://github.com/js-cookie/js-cookie). Currently cookies store `auth_key` and `user_id`, which are required for most API requests.

Closes #8 